### PR TITLE
Fix ActionView to Preserve '?' in Input Names

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -114,7 +114,7 @@ module ActionView
           end
 
           def sanitized_method_name
-            @sanitized_method_name ||= @method_name.delete_suffix("?")
+            @sanitized_method_name ||= @method_name
           end
 
           def sanitized_value(value)


### PR DESCRIPTION
This pull request addresses issue #54822, where ActionView strips the '?' character from input names when building forms. The change modifies the `sanitized_method_name` method in `actionview/lib/action_view/helpers/tags/base.rb` to prevent the automatic removal of the '?' character from method names. 

### Changes Made:
- Updated the `sanitized_method_name` method to return the original method name without stripping the '?' character.

### Expected Outcome:
With this change, forms will now correctly generate input names with the '?' character, aligning with HTML5 standards and allowing for more intuitive form handling without requiring manual workarounds.

---

> This pull request was co-created with Cosine Genie

Original Task: [rails/c0otazo6eqkf](https://cosine.sh/cosinedemo/rails/task/c0otazo6eqkf)
Author: Pandelis Zembashis
